### PR TITLE
Updated for Python3 support

### DIFF
--- a/pep8_magic.py
+++ b/pep8_magic.py
@@ -33,11 +33,11 @@ def pep8(line, cell):
     # remember and replace
     old_stdout = sys.stdout
     # temporary replace
-    sys.stdout = io.BytesIO()
+    sys.stdout = io.StringIO()
     # store code in a file, todo unicode
     with tempfile.NamedTemporaryFile() as f:
         # save to file
-        f.write(cell + "\n")
+        f.write(bytes(cell + '\n', 'UTF-8'))
         # make sure it's written
         f.flush()
         # now we can check the file by name.


### PR DESCRIPTION
I've updated the PEP8 cell magic to support Python3, using a `StringIO` object for the temporary output redirect, and encoding the cell output in binary mode. This fixes #1 
